### PR TITLE
Better error message when partial path is not valid

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,6 +296,8 @@ function partial(view, options){
   var root = dirname(options.filename)
     , file = lookup(root, view, options)
     , key = file + ':string';
+  if( !file )
+    throw new Error('Could not find partial ' + view);
 
   // read view
   var source = options.cache


### PR DESCRIPTION
The code will already throw if the file is null, so might as well 
throw a string that tells the developer more.
