### PR TITLE
Make use of Express@2.5 style of relative path for partials.

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,6 +198,7 @@ function lookup(root, partial, options){
     , key = [ root, partial, ext ].join('-');
 
   if (options.cache && cache[key]) return cache[key];
+  if( options.settings['views'] ) root = options.settings['views'];
 
   // Make sure we use dirname in case of relative partials
   // ex: for partial('../user') look for /path/to/root/../user.ejs
@@ -220,12 +221,6 @@ function lookup(root, partial, options){
   if( exists(partial) ) return options.cache ? cache[key] = partial : partial;
 
   // FIXME:
-  // * there are other path types that Express 2.0 used to support but
-  //   the structure of the lookup involved View class methods that we
-  //   don't have access to any more
-  // * we probaly need to pass the Express app's views folder path into
-  //   this function if we want to support finding partials relative to
-  //   it as well as relative to the current view
   // * we have no tests for finding partials that aren't relative to
   //   the calling view
 


### PR DESCRIPTION
Recently upgraded from express 2.x to 3.x and found that having this small change in place really eased the transition for me because I didn't have to go add preceding slashes to every partial / include in my site. We could change to use `options.settings.views` instead of `options.settings['views']` if you want to be really particular. Otherwise the only other thing I had to change was `res.render('x',{ layout: 'y' })` is now: `res.render('x',{ _layoutFile: 'y' })` ...easy to replace using sed -i so not a big deal.

Thanks for this repo. It was a huge help in migrating from 2.x to 3.x, hopefully this patch helps someone else down the line who also might have piggy-backed of the `app.use('views', xxxx)` feature of express 2.x like I did to augment relative paths for partials.
