### PR TITLE
Added support for theme folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,14 @@ var renderFile = module.exports = function(file, options, fn){
   options.locals.layout  = layout.bind(options);
   options.locals.partial = partial.bind(options);
 
+  //Check if the theme folder is set in options.settings['theme']
+  if (options.settings['theme']) {
+    //Get the file path relative to the theme folder by replacing the options.settings.views path with the options.settings['theme'] path
+    var themeFilePath = dirname(file).replace(resolve(options.settings.views), resolve(options.settings['theme']))
+    //If the current file exists reletive to the theme folder set the file to that path
+    if (fs.existsSync(resolve(themeFilePath, basename(file)))) file = resolve(themeFilePath, basename(file));
+  }
+    
   ejs.renderFile(file, options, function(err, html) {
 
     if (err) {

--- a/index.js
+++ b/index.js
@@ -87,7 +87,16 @@ var renderFile = module.exports = function(file, options, fn){
     //Get the file path relative to the theme folder by replacing the options.settings.views path with the options.settings['theme'] path
     var themeFilePath = dirname(file).replace(resolve(options.settings.views), resolve(options.settings['theme']))
     //If the current file exists reletive to the theme folder set the file to that path
-    if (fs.existsSync(resolve(themeFilePath, basename(file)))) file = resolve(themeFilePath, basename(file));
+    var engine = options.settings['view engine'] || 'ejs'
+    , desiredExt = '.' + engine
+    , ext = extname(file) || desiredExt
+    , key = [themeFilePath, file, ext].join('-');
+    //Load from the cache if it's already been resolved
+    if (options.cache && cache[key]) file = cache[key]; console.log('template loaded from cache');
+    if (fs.existsSync(resolve(themeFilePath, basename(file)))) {
+        cache[key] = resolve(themeFilePath, basename(file));
+        file = resolve(themeFilePath, basename(file));
+    }
   }
     
   ejs.renderFile(file, options, function(err, html) {


### PR DESCRIPTION
If options.settings['theme'] is set by calling

"app.set('theme', __dirname + '/themes/' + storeConfig.ActiveTheme);"

then all templates will be loaded from the themes folder if they exist.
If they don't exist templates will be loaded as usual.
