### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -441,7 +441,7 @@ function block(name, html) {
 // bound to scripts Block in renderFile
 function script(path, type) {
   if (path) {
-    this.append('<script src="'+path+'"'+(type ? 'type="'+type+'"' : '')+'></script>');
+    this.append('<script src="'+path+'"'+(type ? ' type="'+type+'"' : '')+'></script>');
   }
   return this;
 }
@@ -449,7 +449,7 @@ function script(path, type) {
 // bound to stylesheets Block in renderFile
 function stylesheet(path, media) {
   if (path) {
-    this.append('<link rel="stylesheet" href="'+path+'"'+(media ? 'media="'+media+'"' : '')+' />');
+    this.append('<link rel="stylesheet" href="'+path+'"'+(media ? ' media="'+media+'"' : '')+' />');
   }
   return this;
 }


### PR DESCRIPTION
There is no spacing between attributes src and type in <Script>.
Similarly no space between attributes href and media in <link>, 
in functions script and stylesheet
This will produce error if we used the optional attributes. I have made the necessary change in the code. 
