### PR TITLE
Load files (partials, ...) using absolute path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ If you wish not to have to precise the `_basePath` every time, you can set it in
     };
 ```
 
-
 Then you would only need to precise you want to use the global value:
 `views/partials/foo.ejs', {_useAbsolute: true})`
 

--- a/README.md
+++ b/README.md
@@ -107,13 +107,33 @@ When called anywhere inside a template, requests that the output of the current 
 
 When called anywhere inside a template, adds the given view to that template using the current given `optionsOrCollection`. The usual way to use this is to pass an Array as the collection argument. The given view is then executed for each item in the Array; the item is passed into the view as a local with a name generated from the view's filename.
 
-For example, if you do `<%-partial('thing',things)%>` then each item in the `things` Array is passed to `thing.ejs` with the name `thing`. If you rename the template, the local name of each item will correspond to the template name.
+For example, if you do `<%-partial('thing', things)%>` then each item in the `things` Array is passed to `thing.ejs` with the name `thing`. If you rename the template/partial, the local name of each item will correspond to the template name.
+If you do `<%-partial('thing', {things: things, foo: {bar: 'bar')%>` then you will have access to `things` and `foo` from the template/partial, and `foo` would contain a `bar` key.
+
+The `name` can be relative *(default)* or absolute, to use the absolute way you will need to write the following, assuming we are in the `views/layout.ejs` and we want to include the partial located at `views/partials/foo.ejs`: `partial('../partials/foo.ejs', {_basePath: __dirname})`. The `_basePath` attribute is required to set the base path used to include the file.
+
+If you wish not to have to precise the `_basePath` every time, you can set it in a global variable from your `/app.js` for instance:
+
+```
+    __config = {
+      path: {
+        base: __dirname
+      }
+    };
+```
+
+
+Then you would only need to precise you want to use the global value:
+`views/partials/foo.ejs', {_useAbsolute: true})`
+
+
+**As you may have noticed, use the relative way do not need to explicitly write the file extension (.ejs), but the absolute way requires it.**
 
 ### `block(name,html)`
 
 When called anywhere inside a template, adds the given html to the named block. In the layout you can then do `<%-block('foo')%> to render all the html for that block.
 
-Since this relies on javascript strings, and bypasses EJS's default escaping, you should be very careful if you use this function with user-submitted data.
+Since this relies on javascript strings, and bypasses EJS's default escaping, **you should be very careful if you use this function with user-submitted data**.
 
 ### `script(src,type)`
 

--- a/index.js
+++ b/index.js
@@ -207,6 +207,17 @@ function lookup(root, partial, options){
   var dir = dirname(partial)
     , base = basename(partial, ext);
 
+  // If _basePath is provided then load the file using non-relative path.
+  if(options._basePath){
+    partial = resolve(root, options._basePath, partial);
+    if( exists(partial) ){
+      // Update the key to ensure it's unique.
+      key = [ options._basePath, partial, ext ].join('-');
+
+      return options.cache ? cache[key] = partial : partial;
+    }
+  }
+
   // _ prefix takes precedence over the direct path
   // ex: for partial('user') look for /root/_user.ejs
   partial = resolve(root, dir,'_'+base+ext);
@@ -462,4 +473,4 @@ function stylesheet(path, media) {
   return this;
 }
 
-partial('box.ejs', {box_title: 'test'})
+partial('test/fixtures/partials/box.ejs', {_basePath: __dirname, box_title: 'test'})

--- a/index.js
+++ b/index.js
@@ -100,8 +100,12 @@ var renderFile = module.exports = function(file, options, fn){
 
     if (layout) {
 
+      if(!options || !options.settings){
+          options.settings = {};
+      }
+
       // use default extension
-      var engine = options && options.settings && options.settings['view engine'] ? options.settings['view engine'] : 'ejs',
+      var engine = options.settings['view engine'] ? options.settings['view engine'] : 'ejs',
           desiredExt = '.'+engine;
 
       // apply default layout if only "true" was set

--- a/index.js
+++ b/index.js
@@ -207,12 +207,13 @@ function lookup(root, partial, options){
   var dir = dirname(partial)
     , base = basename(partial, ext);
 
-  // If _basePath is provided then load the file using non-relative path.
-  if(options._basePath){
-    partial = resolve(root, options._basePath, partial);
+  // If options_basePath is provided or if a global __config.path.base is available and options._useAbsolute is true then load the file using non-relative path.
+  var basePath = options._basePath ? options._basePath : __config && __config.path && __config.path.base && options._useAbsolute == true ? __config.path.base : false;
+  if(basePath){
+    partial = resolve(root, basePath, partial);
     if( exists(partial) ){
       // Update the key to ensure it's unique.
-      key = [ options._basePath, partial, ext ].join('-');
+      key = [ basePath, partial, ext ].join('-');
 
       return options.cache ? cache[key] = partial : partial;
     }
@@ -474,4 +475,21 @@ function stylesheet(path, media) {
 }
 
 // My own tests.
-//partial('test/fixtures/partials/box.ejs', {_basePath: __dirname, box_title: 'test'})
+
+// A global __config object can be used to always set the basePath by default.
+/*
+var __config = {
+  path: {
+    base: __dirname
+  }
+};
+
+// use the relative path from the current directory.
+partial('test/fixtures/partials/box.ejs', {box_title: 'test'})
+
+// Use the absolute path provided by _basePath
+partial('test/fixtures/partials/box.ejs', {_basePath: __dirname, box_title: 'test'})
+
+// Use the absolute path provided by __config.path.base
+partial('test/fixtures/partials/box.ejs', {_useAbsolute: true, box_title: 'test'})
+*/

--- a/index.js
+++ b/index.js
@@ -59,7 +59,6 @@ var ejs = require('ejs')
  *   </html>
  *
  */
-
 var renderFile = module.exports = function(file, options, fn){
 
   // Express used to set options.locals for us, but now we do it ourselves
@@ -85,6 +84,7 @@ var renderFile = module.exports = function(file, options, fn){
   ejs.renderFile(file, options, function(err, html) {
 
     if (err) {
+      // TODO Improve exceptions?
       return fn(err,html);
     }
 
@@ -160,7 +160,6 @@ var cache = {};
  * @return {String}
  * @api private
  */
-
 function resolveObjectName(view){
   return cache[view] || (cache[view] = view
     .split('/')
@@ -192,7 +191,6 @@ function resolveObjectName(view){
  * @return {String}
  * @api private
  */
-
 function lookup(root, partial, options){
 
   var engine = options.settings['view engine'] || 'ejs'
@@ -413,20 +411,47 @@ function layout(view){
   this.locals._layoutFile = view;
 }
 
+/**
+ * A Block object, used to store HTML content in order to display it anywhere.
+ * @constructor
+ */
 function Block() {
   this.html = [];
 }
 
+/**
+ * Append function to the Block object by prototype.
+ */
 Block.prototype = {
+
+  /**
+   * Convert HTML to string.
+   * @return {string}
+   */
   toString: function() {
     return this.html.join('\n');
   },
+
+  /**
+   * Append a new HTML block.
+   * @param more
+   */
   append: function(more) {
     this.html.push(more);
   },
+
+  /**
+   * Prepend an HTML block, so it's like append it but at the beginning of the array.
+   * @param more
+   */
   prepend: function(more) {
     this.html.unshift(more);
   },
+
+  /**
+   * Replace the whole HTML block by a new array.
+   * @param instead
+   */
   replace: function(instead) {
     this.html = [ instead ];
   }
@@ -458,7 +483,17 @@ function block(name, html) {
   return blk;
 }
 
-// bound to scripts Block in renderFile
+/**
+ * A convenience function for `block('scripts', '<script src="src.js"></script>')` with optional type.
+ * When called anywhere inside a template, adds a script tag with the given src/type to the scripts block.
+ * In the layout you can then do `<%-scripts%> to output the scripts from all the child templates.
+ * This function in bound to the scripts Block from the `renderFile` function.
+ *
+ * @param path
+ * @param media
+ * @return {stylesheet}
+ * @api public
+ */
 function script(path, type) {
   if (path) {
     this.append('<script src="'+path+'"'+(type ? 'type="'+type+'"' : '')+'></script>');
@@ -466,30 +501,20 @@ function script(path, type) {
   return this;
 }
 
-// bound to stylesheets Block in renderFile
+/**
+ * A convenience function for `block('stylesheets', '<link rel="stylesheet" href="href.css" />')` with optional media type.
+ * When called anywhere inside a template, adds a link tag for the stylesheet with the given href/media to the stylesheets block.
+ * In the layout you can then do `<%-stylesheets%> to output the links from all the child templates.
+ * This function in bound to the stylesheets Block from the `renderFile` function.
+ *
+ * @param path
+ * @param media
+ * @return {stylesheet}
+ * @api public
+ */
 function stylesheet(path, media) {
   if (path) {
     this.append('<link rel="stylesheet" href="'+path+'"'+(media ? 'media="'+media+'"' : '')+' />');
   }
   return this;
 }
-
-// My own tests.
-
-// A global __config object can be used to always set the basePath by default.
-/*
-var __config = {
-  path: {
-    base: __dirname
-  }
-};
-
-// use the relative path from the current directory.
-partial('test/fixtures/partials/box.ejs', {box_title: 'test'})
-
-// Use the absolute path provided by _basePath
-partial('test/fixtures/partials/box.ejs', {_basePath: __dirname, box_title: 'test'})
-
-// Use the absolute path provided by __config.path.base
-partial('test/fixtures/partials/box.ejs', {_useAbsolute: true, box_title: 'test'})
-*/

--- a/index.js
+++ b/index.js
@@ -491,7 +491,7 @@ function block(name, html) {
  *
  * @param path
  * @param media
- * @return {stylesheet}
+ * @return {script}
  * @api public
  */
 function script(path, type) {

--- a/index.js
+++ b/index.js
@@ -101,12 +101,12 @@ var renderFile = module.exports = function(file, options, fn){
     if (layout) {
 
       if(!options || !options.settings){
-          options.settings = {};
+        options.settings = {};
       }
 
       // use default extension
       var engine = options.settings['view engine'] ? options.settings['view engine'] : 'ejs',
-          desiredExt = '.'+engine;
+        desiredExt = '.'+engine;
 
       // apply default layout if only "true" was set
       if (layout === true) {
@@ -293,6 +293,10 @@ function partial(view, options){
     }
   } else {
     options = {};
+  }
+
+  if(!options.settings){
+    options.settings = {};
   }
 
   // merge locals into options

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ var renderFile = module.exports = function(file, options, fn){
     if (layout) {
 
       // use default extension
-      var engine = options.settings['view engine'] || 'ejs',
+      var engine = options && options.settings && options.settings['view engine'] ? options.settings['view engine'] : 'ejs',
           desiredExt = '.'+engine;
 
       // apply default layout if only "true" was set
@@ -454,3 +454,4 @@ function stylesheet(path, media) {
   return this;
 }
 
+partial('box.ejs', {box_title: 'test'})

--- a/index.js
+++ b/index.js
@@ -473,4 +473,5 @@ function stylesheet(path, media) {
   return this;
 }
 
-partial('test/fixtures/partials/box.ejs', {_basePath: __dirname, box_title: 'test'})
+// My own tests.
+//partial('test/fixtures/partials/box.ejs', {_basePath: __dirname, box_title: 'test'})

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ],
   "name": "ejs-locals",
   "description": "Express 3.x locals for layout, partial and blocks.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": {
     "type": "git",
     "url": "git://github.com/randometc/ejs-locals.git"

--- a/test/fixtures/partials/box.ejs
+++ b/test/fixtures/partials/box.ejs
@@ -1,6 +1,6 @@
 <% box_content = typeof box_content !== 'undefined' ? box_content : ''%>
 <% box_class = typeof box_class !== 'undefined' ? box_class : 'box'%>
-<% box_id = typeof box_id !== 'undefined' ? box_id : 'box_' + _.uniqueId()%>
+<% box_id = typeof box_id !== 'undefined' ? box_id : 'box_'%>
 <% box_title = typeof box_title !== 'undefined' ? box_title : ''%>
 <% box_title_icon = typeof box_title_icon !== 'undefined' ? box_title_icon : ''%>
 

--- a/test/fixtures/subfolder/box.ejs
+++ b/test/fixtures/subfolder/box.ejs
@@ -1,0 +1,25 @@
+<% box_content = typeof box_content !== 'undefined' ? box_content : ''%>
+<% box_class = typeof box_class !== 'undefined' ? box_class : 'box'%>
+<% box_id = typeof box_id !== 'undefined' ? box_id : 'box_' + _.uniqueId()%>
+<% box_title = typeof box_title !== 'undefined' ? box_title : ''%>
+<% box_title_icon = typeof box_title_icon !== 'undefined' ? box_title_icon : ''%>
+
+<div id="<%= box_id%>" class="<%= box_class %>">
+    <% if(box_title || box_title_icon) {%>
+        <div class="header">
+            <% if(box_title_icon) {%>
+                <span class="icon">
+                    <%- partial('icon', {icon: box_title_icon}) %>
+                </span>
+            <% } %>
+
+            <% if(box_title) {%>
+                <span class="title"><%= box_title %></span>
+            <% } %>
+            <hr>
+        </div>
+    <% } %>
+    <div class="content">
+        <%= typeof box_content == 'function' ? box_content() : box_content%>
+    </div>
+</div>

--- a/test/test.partials.js
+++ b/test/test.partials.js
@@ -12,7 +12,7 @@ app.engine('ejs', engine);
 // (this was the default in Express 2.0 so it's handy for
 // quick ports and upgrades)
 app.locals({
-  _layoutFile: true,
+  _layoutFile: true
 })
 
 app.locals.hello = 'there';


### PR DESCRIPTION
# Load files using absolute path

I've added a way to load files (I tried with partials only) using an absolute path because the relative fails when loading files loaded from a file that has been itself loaded through `include/partial` functions. 
(somehow the path happens to be wrong, sometimes correct depending on which file I save in last and some other weird stuff)

This is a feature that has been asked many times.
## Examples
### 1. Absolute with global config

It is possible to set a `__config` global object that would look like this:

```
__config = {
  path: {
    base: __dirname
  }
};
```

`partial('test/fixtures/partials/box.ejs', {_useAbsolute: true, box_title: 'test'})`

Where `__config.path.base` would contain the basepath of the application, or the basepath from where you want to load files, but would be used only when using `_useAbsolute: true`.
### 2. Absolute with local config

```
// Use the absolute path provided by _basePath
partial('test/fixtures/partials/box.ejs', {_basePath: __dirname, box_title: 'test'})
```

Here you set the `_basePath` when calling the function, I don't like it because I want to use always the same config, or at least most of the time without having to set it each time (see **1. Absolute with global config**)

But I believe it can be useful from time to time.
### 3. Use relative path _(old way, still compatible)_

```
// use the relative path from the current directory.
partial('test/fixtures/partials/box.ejs', {box_title: 'test'})
```
## Design

I decided to use the `_` before the keys I've created to obviously avoid issues. I believe the use of `_` shows the key is somehow private to the function for its own use. I was afraid to mess up existing app by using a common/usual key.
## Test

As I said, I didn't write proper test, I made my tests directly in debug mode. But I have installed my `ejs-locals` on another app to test it and it worked fine there too.
