### PR TITLE
Add license info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "author": "Tom Carden <tom@tom-carden.co.uk>",
+  "license": "MIT",
   "contributors": [
     "Robert Sköld <robert@publicclass.se> (http://publicclass.se)"
   ],


### PR DESCRIPTION
Just added the license info to the package.json. That way the license is available via the NPMRegistry. I'm working on [VersionEye](https://www.versioneye.com) and for us the license info is very important. 
